### PR TITLE
Protect filenotfound exception on import

### DIFF
--- a/prince/data.py
+++ b/prince/data.py
@@ -9,8 +9,15 @@ from prince_config import config
 
 #: Dictionary containing particle properties, like mass, charge
 #: lifetime or branching ratios
-spec_data = pickle.load(
-    open(path.join(config["data_dir"], "particle_data.ppo"), "rb"))
+try:
+    spec_data = pickle.load(
+        open(path.join(config["data_dir"], "particle_data.ppo"), "rb"))
+except UnicodeDecodeError:
+    spec_data = pickle.load(
+        open(path.join(config["data_dir"], "particle_data.ppo"), "rb"), encoding='latin1')
+except FileNotFoundError:
+    info(0, 'Warning, particle database "particle_data.ppo" file not found.')
+
 
 # Default units in Prince are ***cm, s, GeV***
 # Define here all constants and unit conversions and use


### PR DESCRIPTION
This handles the FileNotFound exception with a "warning". For now I would close #15 with it and add take the migration to particletools in the enhancements.