### PR TITLE
Updates for compatibility with recent updates

### DIFF
--- a/prince_cr/cr_sources.py
+++ b/prince_cr/cr_sources.py
@@ -65,7 +65,7 @@ class CosmicRaySource(object, metaclass=ABCMeta):
         num_int = np.zeros_like(self.ncoids, dtype=np.float)
         lum_int = np.zeros_like(self.ncoids, dtype=np.float)
 
-        from scipy.integrate import trapz
+        from scipy.integrate import trapezoid
         for idx, pid in enumerate(self.ncoids):
             # get the inection for the species and subsitute back from E_A =  E / A to E
             s = self.spec_man.ncoid2sref[pid]
@@ -76,8 +76,8 @@ class CosmicRaySource(object, metaclass=ABCMeta):
             # Get the ranges where the energy is greater than Emin and integrate
             mask = np.argwhere(egrid > Emin)
             mask = mask.flatten()
-            num_int[idx] = trapz(injec[mask], egrid[mask])
-            lum_int[idx] = trapz(injec[mask] * egrid[mask], egrid[mask])
+            num_int[idx] = trapezoid(injec[mask], egrid[mask])
+            lum_int[idx] = trapezoid(injec[mask] * egrid[mask], egrid[mask])
         return num_int, lum_int
 
     def injection_rate(self, z):

--- a/prince_cr/cross_sections/base.py
+++ b/prince_cr/cross_sections/base.py
@@ -535,16 +535,16 @@ class CrossSectionBase(object, metaclass=ABCMeta):
                            on self._egrid_tab
         """
 
-        from scipy.integrate import trapz
+        from scipy.integrate import trapezoid
 
         if (mother, daughter) in self._incl_diff_tab:
             # Return the integral of the differential for the inclusive
             egr_incl, cs_diff = self.incl_diff(mother, daughter)
             # diff_mat = diff_mat.transpose()
-            cs_incl = trapz(cs_diff,
-                            x=self.xcenters,
-                            dx=bin_widths(self.xbins),
-                            axis=0)
+            cs_incl = trapezoid(cs_diff,
+                                x=self.xcenters,
+                                dx=bin_widths(self.xbins),
+                                axis=0)
 
             if isinstance(self._incl_diff_tab[(mother, daughter)], tuple):
                 return egr_incl, cs_incl

--- a/prince_cr/cross_sections/photo_meson.py
+++ b/prince_cr/cross_sections/photo_meson.py
@@ -154,11 +154,11 @@ class SophiaSuperposition(CrossSectionBase):
         if daughter <= 101:
             # raise Exception('Boost conserving cross section called ' +
             #                 'for redistributed particle')
-            from scipy.integrate import trapz
+            from scipy.integrate import trapezoid
 
             _, cs_diff = self.incl_diff(mother, daughter)
-            cs_incl = trapz(cs_diff, x=self.xcenters,
-                            dx=bin_widths(self.xbins), axis=0)
+            cs_incl = trapezoid(cs_diff, x=self.xcenters,
+                                dx=bin_widths(self.xbins), axis=0)
             return self.egrid, cs_incl[self._range]
 
         elif daughter >= 200 and daughter not in [mother - 101, mother - 100]:
@@ -377,12 +377,12 @@ class EmpiricalModel(SophiaSuperposition):
         """Computes inclusive from nonel * M with M is
         multiplicity value stored in internal table
         """
-        from scipy.integrate import trapz
+        from scipy.integrate import trapezoid
 
         if daughter <= config.redist_threshold_ID:
             _, cs_diff = self.incl_diff(mother, daughter)
-            cs_incl = trapz(cs_diff, x=self.xcenters,
-                            dx=bin_widths(self.xbins), axis=0)
+            cs_incl = trapezoid(cs_diff, x=self.xcenters,
+                                dx=bin_widths(self.xbins), axis=0)
             return self.egrid, cs_incl[self._range]
         elif (mother, daughter) in self.multiplicity:
             egrid, cs_nonel = self.nonel(mother)
@@ -404,12 +404,12 @@ class EmpiricalModel(SophiaSuperposition):
                 self.multiplicity[mother, daughter] * cs_nonel / xw
         elif (mother > 101) and (daughter in [2, 3, 4]):  # if it's a pion rescale to A^2/3
             def superposition_incl(mother, daughter):
-                from scipy.integrate import trapz
+                from scipy.integrate import trapezoid
                 _, Z, N = get_AZN(mother)
                 cs_diff = self.redist_proton[daughter].T * Z * self.cs_proton_grid + \
                     self.redist_neutron[daughter].T * N * self.cs_neutron_grid
-                cs_incl = trapz(cs_diff, x=self.xcenters,
-                                dx=bin_widths(self.xbins), axis=0)
+                cs_incl = trapezoid(cs_diff, x=self.xcenters,
+                                    dx=bin_widths(self.xbins), axis=0)
                 return cs_incl[self._range]
 
             def superposition_multiplicities(mother ,daughter):

--- a/prince_cr/cross_sections/response.py
+++ b/prince_cr/cross_sections/response.py
@@ -102,8 +102,8 @@ class ResponseFunction(object):
         else:
             egrid, cross_section = cs_model.nonel(mother)
 
-    # note that cumtrapz works also for 2d-arrays and will integrate along axis = 1
-        integral = integrate.cumtrapz(egrid * cross_section, x=egrid)
+    # note that cumulative_trapezoid works also for 2d-arrays and will integrate along axis = 1
+        integral = integrate.cumulative_trapezoid(egrid * cross_section, x=egrid)
         ygrid = egrid[1:] / 2.
 
         return ygrid, integral / (2 * ygrid**2)
@@ -161,9 +161,9 @@ class ResponseFunction(object):
             self.incl_diff_intp[(mother, daughter)] = get_2Dinterp_object(
                 self.xcenters, ygr, rfunc, self.cross_section.xbins)
 
-            from scipy.integrate import cumtrapz
-            integral = cumtrapz(rfunc, ygr, axis=1,initial=0)
-            integral = cumtrapz(integral, self.xcenters, axis=0,initial=0)
+            from scipy.integrate import cumulative_trapezoid
+            integral = cumulative_trapezoid(rfunc, ygr, axis=1,initial=0)
+            integral = cumulative_trapezoid(integral, self.xcenters, axis=0,initial=0)
 
             self.incl_diff_intp_integral[(mother, daughter)] = get_2Dinterp_object(
                 self.xcenters, ygr, integral, self.cross_section.xbins)

--- a/prince_cr/data.py
+++ b/prince_cr/data.py
@@ -122,7 +122,7 @@ class PrinceDB(object):
                 X = np.array(spl_gr['x'])
                 interp2d_transposed = RectBivariateSpline(X[::-1], spl_gr['y'], Z[::-1, :])
 
-            interp2d = lambda xval, yval: interp2d_transposed(xval, yval).T
+            interp2d = lambda xval, yval: interp2d_transposed(xval, yval).T.squeeze()
 
             return interp2d
 

--- a/prince_cr/data.py
+++ b/prince_cr/data.py
@@ -104,7 +104,7 @@ class PrinceDB(object):
         return db_entry
 
     def ebl_spline(self, model_tag, subset='base'):
-        from scipy.interpolate import interp2d
+        from scipy.interpolate import RectBivariateSpline
         info(10, 'Reading EBL field splines. tag={0}'.format(model_tag))
         with h5py.File(self.prince_db_fname, 'r') as prince_db:
             self._check_subgroup_exists(prince_db['EBL_models'],
@@ -112,9 +112,11 @@ class PrinceDB(object):
             self._check_subgroup_exists(prince_db['EBL_models'][model_tag],
                                         subset)
             spl_gr = prince_db['EBL_models'][model_tag][subset]
+            
+            interp2d_transposed = RectBivariateSpline(spl_gr['x'], spl_gr['y'], spl_gr['z'].T)
+            interp2d = lambda xval, yval: interp2d_transposed(xval, yval).T
 
-            return interp2d(spl_gr['x'], spl_gr['y'], spl_gr['z'],
-                            fill_value=0., kind='linear')
+            return interp2d
 
 #: db_handler is the HDF file interface
 db_handler = PrinceDB()

--- a/prince_cr/data.py
+++ b/prince_cr/data.py
@@ -122,7 +122,8 @@ class PrinceDB(object):
                 X = np.array(spl_gr['x'])
                 interp2d_transposed = RectBivariateSpline(X[::-1], spl_gr['y'], Z[::-1, :])
 
-            interp2d = lambda xval, yval: interp2d_transposed(xval, yval).T.squeeze()
+            def interp2d(xval, yval):
+                return interp2d_transposed(xval, yval).T.squeeze()
 
             return interp2d
 

--- a/prince_cr/data.py
+++ b/prince_cr/data.py
@@ -50,6 +50,30 @@ UNITS_AND_CONVERSIONS_DEF = dict(
 PRINCE_UNITS = convert_to_namedtuple(UNITS_AND_CONVERSIONS_DEF, "PriNCeUnits")
 
 
+class ebl_interpolator(object):
+    """Provides an interpolator to replace previously used interp2d.
+
+    To be used in the class PrinceDB below, in the function ebl_spline.
+    """
+    def __init__(self, spline_grid):
+        from scipy.interpolate import RectBivariateSpline
+
+        Z = np.array(spline_grid['z']).T
+        
+        if np.all(np.diff(spline_grid['x']) > 0):
+            # increasing values
+            interp2d_transposed = RectBivariateSpline(spline_grid['x'], spline_grid['y'], Z)
+        elif np.all(np.diff(spline_grid['x']) < 0):
+            # decreasing values
+            X = np.array(spline_grid['x'])
+            interp2d_transposed = RectBivariateSpline(X[::-1], spline_grid['y'], Z[::-1, :])
+
+        self._interpolator = interp2d_transposed
+
+    def __call__(self, xval, yval):
+        return self._interpolator(xval, yval).T.squeeze()
+
+
 class PrinceDB(object):
     """Provides access to data stored in an HDF5 file.
 
@@ -104,7 +128,7 @@ class PrinceDB(object):
         return db_entry
 
     def ebl_spline(self, model_tag, subset='base'):
-        from scipy.interpolate import RectBivariateSpline
+        
         info(10, 'Reading EBL field splines. tag={0}'.format(model_tag))
         with h5py.File(self.prince_db_fname, 'r') as prince_db:
             self._check_subgroup_exists(prince_db['EBL_models'],
@@ -112,20 +136,8 @@ class PrinceDB(object):
             self._check_subgroup_exists(prince_db['EBL_models'][model_tag],
                                         subset)
             spl_gr = prince_db['EBL_models'][model_tag][subset]
-            
-            Z = np.array(spl_gr['z']).T
-            if np.all(np.diff(spl_gr['x']) > 0):
-                # increasing values
-                interp2d_transposed = RectBivariateSpline(spl_gr['x'], spl_gr['y'], Z)
-            elif np.all(np.diff(spl_gr['x']) < 0):
-                # decreasing values
-                X = np.array(spl_gr['x'])
-                interp2d_transposed = RectBivariateSpline(X[::-1], spl_gr['y'], Z[::-1, :])
 
-            def interp2d(xval, yval):
-                return interp2d_transposed(xval, yval).T.squeeze()
-
-            return interp2d
+            return ebl_interpolator(spl_gr)
 
 #: db_handler is the HDF file interface
 db_handler = PrinceDB()

--- a/prince_cr/data.py
+++ b/prince_cr/data.py
@@ -113,7 +113,15 @@ class PrinceDB(object):
                                         subset)
             spl_gr = prince_db['EBL_models'][model_tag][subset]
             
-            interp2d_transposed = RectBivariateSpline(spl_gr['x'], spl_gr['y'], np.array(spl_gr['z']).T)
+            Z = np.array(spl_gr['z']).T
+            if np.all(np.diff(spl_gr['x']) > 0):
+                # increasing values
+                interp2d_transposed = RectBivariateSpline(spl_gr['x'], spl_gr['y'], Z)
+            elif np.all(np.diff(spl_gr['x']) < 0):
+                # decreasing values
+                X = np.array(spl_gr['x'])
+                interp2d_transposed = RectBivariateSpline(X[::-1], spl_gr['y'], Z[::-1, :])
+
             interp2d = lambda xval, yval: interp2d_transposed(xval, yval).T
 
             return interp2d

--- a/prince_cr/data.py
+++ b/prince_cr/data.py
@@ -113,7 +113,7 @@ class PrinceDB(object):
                                         subset)
             spl_gr = prince_db['EBL_models'][model_tag][subset]
             
-            interp2d_transposed = RectBivariateSpline(spl_gr['x'], spl_gr['y'], spl_gr['z'].T)
+            interp2d_transposed = RectBivariateSpline(spl_gr['x'], spl_gr['y'], np.array(spl_gr['z']).T)
             interp2d = lambda xval, yval: interp2d_transposed(xval, yval).T
 
             return interp2d

--- a/prince_cr/decays.py
+++ b/prince_cr/decays.py
@@ -1,7 +1,7 @@
 """The module contains everything to handle cross section interfaces."""
 
 import numpy as np
-from scipy.integrate import trapz
+from scipy.integrate import trapezoid
 
 from prince_cr.util import info, get_AZN
 from prince_cr.data import spec_data
@@ -151,7 +151,7 @@ def get_decay_matrix_bin_average(mo, da, x_lower, x_upper):
     x_grid = (x_upper + x_lower) / 2
 
     # remember shape, but only calculate for last column, as x repeats in each column
-    from scipy.integrate import trapz
+    from scipy.integrate import trapezoid
     shape = x_grid.shape
 
     if len(shape) == 2:
@@ -531,11 +531,11 @@ def nu_from_beta_decay(x_grid, mother, daughter, Gamma=200, angle=None):
              'No angle averaging performed!')
     elif angle is None:
         # now average over angle
-        res = trapz(res, x=ctheta, axis=1)
-        res = res / trapz(res, x=x_grid)
+        res = trapezoid(res, x=ctheta, axis=1)
+        res = res / trapezoid(res, x=x_grid)
     else:
         res = res[:, 0]
-        res = res / trapz(res, x=x_grid)
+        res = res / trapezoid(res, x=x_grid)
 
     return res
 

--- a/prince_cr/interaction_rates.py
+++ b/prince_cr/interaction_rates.py
@@ -1,7 +1,7 @@
 """The module contains classes for computations of interaction rates"""
 
 import numpy as np
-from scipy.integrate import trapz
+from scipy.integrate import trapezoid
 
 from prince_cr.data import PRINCE_UNITS
 from prince_cr.util import info
@@ -483,7 +483,7 @@ class ContinuousPairProductionLossRate(object):
     def loss_vector(self, z):
         """Returns all continuous losses on dim_states grid"""
 
-        rate_single = trapz(
+        rate_single = trapezoid(
             self.photon_vector(z) * self.phi_xi2, self.xi, axis=1)
         pprod_loss_vector = self.scale_vec * np.tile(rate_single,
                                                      self.spec_man.nspec)

--- a/prince_cr/photonfields.py
+++ b/prince_cr/photonfields.py
@@ -7,7 +7,7 @@ from abc import abstractmethod
 from os.path import join
 
 import numpy as np
-from scipy.integrate import trapz
+from scipy.integrate import trapezoid
 from scipy.interpolate import UnivariateSpline
 
 import prince_cr.config as config
@@ -146,7 +146,7 @@ class EBLSplined2D(PhotonField):
             Ered = E / (1. + z)
             nlocal = self.int2d(Ered, 0., assume_sorted=True)
             nz = self.int2d(Ered, z, assume_sorted=True)
-            scale = trapz(nz,Ered) / trapz(nlocal,Ered) / (1+z)**3
+            scale = trapezoid(nz,Ered) / trapezoid(nlocal,Ered) / (1+z)**3
             # print(scale)
             return (1. + z)**2 * nlocal * scale
         else:

--- a/prince_cr/photonfields.py
+++ b/prince_cr/photonfields.py
@@ -144,13 +144,13 @@ class EBLSplined2D(PhotonField):
         # pylint:disable=not-callable
         if self.simple_scaling:
             Ered = E / (1. + z)
-            nlocal = self.int2d(Ered, 0., assume_sorted=True)
-            nz = self.int2d(Ered, z, assume_sorted=True)
+            nlocal = self.int2d(Ered, 0.)
+            nz = self.int2d(Ered, z)
             scale = trapezoid(nz,Ered) / trapezoid(nlocal,Ered) / (1+z)**3
             # print(scale)
             return (1. + z)**2 * nlocal * scale
         else:
-            return self.int2d(E, z, assume_sorted=True)
+            return self.int2d(E, z)
 
 class CIBFranceschini2D(EBLSplined2D):
     """CIB model "1" by Fraceschini et al.
@@ -280,7 +280,7 @@ class CIBFranceschiniZ0(PhotonField):
             raise Exception(self.__class__.__name__ + 'get_photon_density(): '
                             + 'Redshift z > 0 not supported by this class')
 
-        return self.spl_ngamma(E, assume_sorted=True)
+        return self.spl_ngamma(E)
 
 
 class CIBSteckerZ0(PhotonField):
@@ -359,7 +359,7 @@ class CIBSteckerZ0(PhotonField):
             raise Exception(self.__class__.__name__ + 'get_photon_density(): '
                             + 'Redshift z > 0 not supported by this class')
 
-        return self.spl_ngamma(E, assume_sorted=True)
+        return self.spl_ngamma(E)
 
 
 if __name__ == "__main__":

--- a/prince_cr/solvers/propagation.py
+++ b/prince_cr/solvers/propagation.py
@@ -82,7 +82,7 @@ class UHECRPropagationResult(object):
         if egrid is None:
             max_mass = max([s.A for s in self.spec_man.species_refs])
             emin_log, emax_log, nbins = list(config.cosmic_ray_grid)
-            emax_log = np.log10(max_mass * 10**emax_log)
+            emax_log = np.log10(max_mass * 10**float(emax_log))
             nbins *= 4
             com_egrid = EnergyGrid(emin_log, emax_log, nbins).grid
         else:

--- a/prince_cr/solvers/propagation.py
+++ b/prince_cr/solvers/propagation.py
@@ -153,10 +153,10 @@ class UHECRPropagationResult(object):
         return com_egrid, average, variance
 
     def get_energy_density(self, nco_id):
-        from scipy.integrate import trapz
+        from scipy.integrate import trapezoid
 
         A = self.spec_man.ncoid2sref[nco_id].A
-        return trapz(A * self.egrid * self.get_solution(nco_id), self.egrid)
+        return trapezoid(A * self.egrid * self.get_solution(nco_id), self.egrid)
 
 
 class UHECRPropagationSolver(object):


### PR DESCRIPTION
This PR addresses incompatibilities in the code with recent versions of SciPy. In particular, fixes to avoid deprecated functions (trapz, cumtrapz, interp2d) and  some other fixes to address issues produced by the updated functions. The largest piece of code is a trivial class to hold the interpolating function for ebl models, in order to address the deprecation of interp2d properly. This class was needed in particular to allow pickle.dump of the kernel, as a simpler lambda function (see 98c887167607412380793f298113264942908c1c and 4e5a0fb85586bf78879ea6fed6951c33292b07ae) worked well, but raised errors when trying to pickle.dump a precomputed kernel. 
This updates have been verified by running the three basic examples in https://github.com/joheinze/PriNCe-examples#1c6e7930c5edbe13c41910c61ce09c86eb491e65 which was not possible before the changes in this PR when using the latest SciPy 1.17.